### PR TITLE
generic `extend`

### DIFF
--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -304,17 +304,22 @@ impl Chain {
 
     /// Join this Chain with another Chain, this moves all atoms from the other Chain
     /// to this Chain. All other (meta) data of this Chain will stay the same.
-    pub fn join(&mut self, other: Chain) {
-        for atom in other.atoms() {
-            self.add_atom(
-                atom.clone(),
-                atom.residue().serial_number(),
-                atom.residue().id_array(),
-            )
+    pub fn extend<T>(&mut self, other: T) where T: IntoIterator<Item = Residue> {
+        for residue in other.into_iter() {
+            self.add_residue(residue);
         }
-        self.fix_pointers_of_children();
     }
 }
+
+impl IntoIterator for Chain {
+    type Item = Residue;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.residues.into_iter()
+    }
+}
+
+
 
 use std::fmt;
 impl fmt::Display for Chain {


### PR DESCRIPTION
This allows extending not only with a `Chain` but also with other collections such as `Vec<Residue>`

This method is more reminiscent of `std`'s [`extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html#tymethod.extend) than [`join`](https://doc.rust-lang.org/std/slice/trait.Join.html#tymethod.join), so I renamed it to `extend`.