### PR TITLE
add atom names and residues to reference table

### DIFF
--- a/src/reference_tables.rs
+++ b/src/reference_tables.rs
@@ -282,14 +282,16 @@ const ELEMENT_BOND_RADII: &[(usize, Option<usize>, Option<usize>)] = &[
     (157, None, None),
 ];
 
-/// All amino acids
+/// All amino acids. Includes Amber-specific naming conventions for (de-)protonated versions, CYS involved in
+/// disulfide bonding and the like.
 const AMINO_ACIDS: &[&str] = &[
-    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS", "ILE", "LEU", "LYS", "MET",
-    "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL",
+    "ALA", "ARG", "ASH", "ASN", "ASP", "CYS", "CYX", "GLH", "GLN", "GLU", "GLY", "HID", "HIE",
+    "HIM", "HIP", "HIS", "ILE", "LEU", "LYN", "LYS", "MET", "PHE", "PRO", "SER", "THR", "TRP",
+    "TYR", "VAL",
 ];
 
 /// The names of atom in the backbone of proteins
-const BACKBONE_NAMES: &[&str] = &["N", "CA", "C", "O"];
+const BACKBONE_NAMES: &[&str] = &["N", "CA", "C", "O", "H", "H1", "H2", "HA", "HA2", "HA3"];
 
 /// The list of Hermann Mauguin symbols in the same order as in the handbook
 const HERMANN_MAUGUIN_SYMBOL: &[&str] = &[

--- a/src/reference_tables.rs
+++ b/src/reference_tables.rs
@@ -291,7 +291,7 @@ const AMINO_ACIDS: &[&str] = &[
 ];
 
 /// The names of atom in the backbone of proteins
-const BACKBONE_NAMES: &[&str] = &["N", "CA", "C", "O", "H", "H1", "H2", "HA", "HA2", "HA3"];
+const BACKBONE_NAMES: &[&str] = &["N", "CA", "C", "O", "H", "H1", "H2", "H3", "HA", "HA2", "HA3"];
 
 /// The list of Hermann Mauguin symbols in the same order as in the handbook
 const HERMANN_MAUGUIN_SYMBOL: &[&str] = &[


### PR DESCRIPTION
This PR is somewhat optional because it caters to my personal use case of the library.
I added this because it is useful for me to identify amino acids and backbone atoms but only in PDB files where H atoms have been added. Also, since I usually work with processed PDB files, there is some domain-specific naming of (de-)protonated versions of the amino acids, CYS residues engaged in S-bonding and so on.

I think the addition to the backbone atom names should be fine, these find the H atoms of the N-terminus and GLY. The "H1, H2, H3" atom names can also refer to H atoms in, e.g., water but since the backbone atom check includes a check for amino acid identity, this should not be a problem.
As the addition to the amino acid names is situational (and other naming conventions probably exist in other force fields than Amber), I would leave it up to you if you want to merge this.