### PR TITLE
Hierarchy mut

### DIFF
--- a/src/structs/atom_with_hierarchy_mut.rs
+++ b/src/structs/atom_with_hierarchy_mut.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::cell::RefCell;
+// use std::cell::RefCell;
 
 /// A structure containing references to the full hierarchy for a single Atom which is wrapped in a RefCell
 /// to provide interior mutability.
@@ -12,13 +12,13 @@ pub struct AtomWithHierarchyMut<'a> {
     /// The Conformer containing this Atom
     pub conformer: &'a Conformer,
     /// This Atom
-    pub atom: RefCell<&'a Atom>,
+    pub atom: Atom,
 }
 
 impl<'a> AtomWithHierarchyMut<'a> {
     /// Create an AtomWithHierarchyMut from a Tuple containing all needed references
     pub fn from_tuple(
-        hierarchy: (&'a Chain, &'a Residue, &'a Conformer, RefCell<&'a Atom>),
+        hierarchy: (&'a Chain, &'a Residue, &'a Conformer, Atom),
     ) -> AtomWithHierarchyMut<'a> {
         AtomWithHierarchyMut {
             chain: hierarchy.0,
@@ -32,7 +32,7 @@ impl<'a> AtomWithHierarchyMut<'a> {
         chain: &'a Chain,
         residue: &'a Residue,
         conformer: &'a Conformer,
-        atom: RefCell<&'a Atom>,
+        atom: Atom,
     ) -> AtomWithHierarchyMut<'a> {
         AtomWithHierarchyMut {
             chain,
@@ -44,12 +44,12 @@ impl<'a> AtomWithHierarchyMut<'a> {
 
     /// Tests if this atom is part of the protein backbone
     pub fn is_backbone(&self) -> bool {
-        self.conformer.is_amino_acid() && self.atom.borrow().is_backbone()
+        self.conformer.is_amino_acid() && self.atom.is_backbone()
     }
 
     /// Tests if this atom is part of a side chain of an amino acid
     pub fn is_side_chain(&self) -> bool {
-        self.conformer.is_amino_acid() && !self.atom.borrow().hetero()
+        self.conformer.is_amino_acid() && !self.atom.hetero()
     }
 }
 
@@ -60,7 +60,7 @@ impl<'a> PartialEq for AtomWithHierarchyMut<'a> {
         // By definition the combination of serial number and alternative location should be
         // unique across the whole PDB, this does not account for the fact that there could
         // be multiple models, but that is impossible to check anyway without Model information.
-        self.atom.borrow().serial_number() == other.atom.borrow().serial_number()
+        self.atom.serial_number() == other.atom.serial_number()
             && self.conformer.alternative_location() == other.conformer.alternative_location()
     }
 }

--- a/src/structs/atom_with_hierarchy_mut.rs
+++ b/src/structs/atom_with_hierarchy_mut.rs
@@ -1,0 +1,66 @@
+use super::*;
+use std::cell::RefCell;
+
+/// A structure containing references to the full hierarchy for a single Atom which is wrapped in a RefCell
+/// to provide interior mutability.
+#[derive(Debug, Clone)]
+pub struct AtomWithHierarchyMut<'a> {
+    /// The Chain containing this Atom
+    pub chain: &'a Chain,
+    /// The Residue containing this Atom
+    pub residue: &'a Residue,
+    /// The Conformer containing this Atom
+    pub conformer: &'a Conformer,
+    /// This Atom
+    pub atom: RefCell<&'a Atom>,
+}
+
+impl<'a> AtomWithHierarchyMut<'a> {
+    /// Create an AtomWithHierarchyMut from a Tuple containing all needed references
+    pub fn from_tuple(
+        hierarchy: (&'a Chain, &'a Residue, &'a Conformer, RefCell<&'a Atom>),
+    ) -> AtomWithHierarchyMut<'a> {
+        AtomWithHierarchyMut {
+            chain: hierarchy.0,
+            residue: hierarchy.1,
+            conformer: hierarchy.2,
+            atom: hierarchy.3,
+        }
+    }
+    /// Create an AtomWithHierarchyMut from all needed references
+    pub fn new(
+        chain: &'a Chain,
+        residue: &'a Residue,
+        conformer: &'a Conformer,
+        atom: RefCell<&'a Atom>,
+    ) -> AtomWithHierarchyMut<'a> {
+        AtomWithHierarchyMut {
+            chain,
+            residue,
+            conformer,
+            atom,
+        }
+    }
+
+    /// Tests if this atom is part of the protein backbone
+    pub fn is_backbone(&self) -> bool {
+        self.conformer.is_amino_acid() && self.atom.borrow().is_backbone()
+    }
+
+    /// Tests if this atom is part of a side chain of an amino acid
+    pub fn is_side_chain(&self) -> bool {
+        self.conformer.is_amino_acid() && !self.atom.borrow().hetero()
+    }
+}
+
+impl<'a> Eq for AtomWithHierarchyMut<'a> {}
+
+impl<'a> PartialEq for AtomWithHierarchyMut<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        // By definition the combination of serial number and alternative location should be
+        // unique across the whole PDB, this does not account for the fact that there could
+        // be multiple models, but that is impossible to check anyway without Model information.
+        self.atom.borrow().serial_number() == other.atom.borrow().serial_number()
+            && self.conformer.alternative_location() == other.conformer.alternative_location()
+    }
+}

--- a/src/structs/atom_with_hierarchy_mut.rs
+++ b/src/structs/atom_with_hierarchy_mut.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::cell::RefCell;
 
 /// A structure containing references to the full hierarchy for a single Atom
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AtomWithHierarchyMut<'a> {
     /// The Chain containing this Atom
     pub chain: &'a Chain,
@@ -11,13 +11,14 @@ pub struct AtomWithHierarchyMut<'a> {
     /// The Conformer containing this Atom
     pub conformer: &'a Conformer,
     /// This Atom
-    pub atom: RefCell<&'a Atom>,
+    // pub atom: RefCell<&'a Atom>,
+    pub atom: RefCell<Atom>,
 }
 
 impl<'a> AtomWithHierarchyMut<'a> {
     /// Create an AtomWithHierarchyMut from a Tuple containing all needed references
     pub fn from_tuple(
-        hierarchy: (&'a Chain, &'a Residue, &'a Conformer, RefCell<&'a Atom>),
+        hierarchy: (&'a Chain, &'a Residue, &'a Conformer, RefCell<Atom>),
     ) -> AtomWithHierarchyMut<'a> {
         AtomWithHierarchyMut {
             chain: hierarchy.0,
@@ -31,7 +32,7 @@ impl<'a> AtomWithHierarchyMut<'a> {
         chain: &'a Chain,
         residue: &'a Residue,
         conformer: &'a Conformer,
-        atom: RefCell<&'a Atom>,
+        atom: RefCell<Atom>,
     ) -> AtomWithHierarchyMut<'a> {
         AtomWithHierarchyMut {
             chain,
@@ -61,14 +62,6 @@ impl<'a> PartialEq for AtomWithHierarchyMut<'a> {
         // be multiple models, but that is impossible to check anyway without Model information.
         self.atom.borrow().serial_number() == other.atom.borrow().serial_number()
             && self.conformer.alternative_location() == other.conformer.alternative_location()
-    }
-}
-
-impl<'a> std::ops::Deref for AtomWithHierarchyMut<'a> {
-    type Target = RefCell<&'a Atom>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.atom
     }
 }
 

--- a/src/structs/atom_with_hierarchy_mut.rs
+++ b/src/structs/atom_with_hierarchy_mut.rs
@@ -65,21 +65,21 @@ impl<'a> PartialEq for AtomWithHierarchyMut<'a> {
     }
 }
 
-#[cfg(feature = "rstar")]
-use rstar::{PointDistance, RTreeObject, AABB};
+// #[cfg(feature = "rstar")]
+// use rstar::{PointDistance, RTreeObject, AABB};
 
-#[cfg(feature = "rstar")]
-impl<'a> RTreeObject for AtomWithHierarchyMut<'a> {
-    type Envelope = AABB<[f64; 3]>;
+// #[cfg(feature = "rstar")]
+// impl<'a> RTreeObject for AtomWithHierarchyMut<'a> {
+//     type Envelope = AABB<[f64; 3]>;
 
-    fn envelope(&self) -> Self::Envelope {
-        self.atom.envelope()
-    }
-}
+//     fn envelope(&self) -> Self::Envelope {
+//         self.atom.borrow().envelope()
+//     }
+// }
 
-#[cfg(feature = "rstar")]
-impl<'a> PointDistance for AtomWithHierarchyMut<'a> {
-    fn distance_2(&self, other: &[f64; 3]) -> f64 {
-        self.atom.distance_2(other)
-    }
-}
+// #[cfg(feature = "rstar")]
+// impl<'a> PointDistance for AtomWithHierarchyMut<'a> {
+//     fn distance_2(&self, other: &[f64; 3]) -> f64 {
+//         self.atom.borrow().distance_2(other)
+//     }
+// }

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 mod atom;
 mod atom_with_hierarchy;
+mod atom_with_hierarchy_mut;
 mod bond;
 mod chain;
 mod conformer;
@@ -15,6 +16,7 @@ mod unit_cell;
 
 pub use atom::Atom;
 pub use atom_with_hierarchy::AtomWithHierarchy;
+pub use atom_with_hierarchy_mut::AtomWithHierarchyMut;
 pub use bond::Bond;
 pub use chain::Chain;
 pub use conformer::Conformer;

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -6,7 +6,6 @@ use doc_cfg::doc_cfg;
 use rayon::prelude::*;
 use std::cell::RefCell;
 use std::cmp::Ordering;
-// use std::cell::RefCell;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -344,7 +343,7 @@ impl<'a> Model {
             .map(|ch| {
                 ch.residues().map(move |r| {
                     r.conformers()
-                        .map(move |c| c.atoms().map(move |a| (ch, r, c, RefCell::new(a))))
+                        .map(move |c| c.atoms().map(move |a| (ch, r, c, RefCell::new(a.clone()))))
                 })
             })
             .flatten()

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -5,7 +5,7 @@ use doc_cfg::doc_cfg;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 use std::cmp::Ordering;
-use std::cell::RefCell;
+// use std::cell::RefCell;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -343,7 +343,7 @@ impl<'a> Model {
             .map(|ch| {
                 ch.residues().map(move |r| {
                     r.conformers()
-                        .map(move |c| c.atoms().map(move |a| (ch, r, c, RefCell::new(a))))
+                        .map(move |c| c.atoms().map(move |a| (ch, r, c, a.clone())))
                 })
             })
             .flatten()

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -4,6 +4,7 @@ use crate::transformation::*;
 use doc_cfg::doc_cfg;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
+use std::cell::RefCell;
 use std::cmp::Ordering;
 // use std::cell::RefCell;
 
@@ -318,7 +319,7 @@ impl<'a> Model {
         self.par_chains_mut().flat_map(|a| a.par_atoms_mut())
     }
 
-    /// Returns all atoms with their hierarchy struct for each atom in this model.
+    /// Returns all atom with their hierarchy struct for each atom in this model.
     pub fn atoms_with_hierarchy(
         &'a self,
     ) -> impl DoubleEndedIterator<Item = AtomWithHierarchy<'a>> + '_ {
@@ -335,7 +336,7 @@ impl<'a> Model {
             .map(AtomWithHierarchy::from_tuple)
     }
 
-    /// Returns all atoms as mutable with their hierarchy struct for each atom in this model.
+    /// Returns all atom with their hierarchy struct for each atom in this model.
     pub fn atoms_with_hierarchy_mut(
         &'a self,
     ) -> impl DoubleEndedIterator<Item = AtomWithHierarchyMut<'a>> + '_ {
@@ -343,7 +344,7 @@ impl<'a> Model {
             .map(|ch| {
                 ch.residues().map(move |r| {
                     r.conformers()
-                        .map(move |c| c.atoms().map(move |a| (ch, r, c, a.clone())))
+                        .map(move |c| c.atoms().map(move |a| (ch, r, c, RefCell::new(a))))
                 })
             })
             .flatten()

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -568,6 +568,14 @@ impl<'a> PDB {
         self.models().flat_map(|m| m.atoms_with_hierarchy())
     }
 
+    /// Get the list of mutable Atoms with their hierarchies making up this PDB, including all models.
+    /// Double ended so iterating from the end is just as fast as from the start.
+    pub fn atoms_with_hierarchy_mut(
+        &'a self,
+    ) -> impl DoubleEndedIterator<Item = AtomWithHierarchyMut<'a>> + '_ {
+        self.models().flat_map(|m| m.atoms_with_hierarchy_mut())
+    }
+
     /// Get the list of Atoms with their hierarchies making up this PDB, including all models.
     #[doc_cfg(feature = "rayon")]
     pub fn par_atoms_with_hierarchy(

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -568,7 +568,7 @@ impl<'a> PDB {
         self.models().flat_map(|m| m.atoms_with_hierarchy())
     }
 
-    /// Get the list of mutable Atoms with their hierarchies making up this PDB, including all models.
+    /// Get the list of Atoms with their hierarchies making up this PDB, including all models.
     /// Double ended so iterating from the end is just as fast as from the start.
     pub fn atoms_with_hierarchy_mut(
         &'a self,


### PR DESCRIPTION
Fix #69 
Here is a very preliminary version of what I envisioned. As I mentioned in #69 I created a struct were only the `Atom`is mutable. I suppose the other fields could also be wrapped in `RefCell`s and appropriate methods defined.
The biggest issue I see so far is that I had to clone every `Atom` in the `model::atoms_with_hierarchy_mut` which is probably somewhat expensive and is even less attractive if this had to be done for the other fields as well.
Maybe the `RefCell`can be wrapped in an `Rc` pointer but for the moment I got kind of stuck when trying to figure out a way to do this.
Also I don't know how to make the `rstar` features work with the new struct but I put that aside for now.